### PR TITLE
local_optimisation supporting variables in shape of n*d ndarray

### DIFF
--- a/Exer4_24.py
+++ b/Exer4_24.py
@@ -1,0 +1,56 @@
+import numpy as np
+import math
+from pair_potential.pair_potential import fast_pair_potential
+from pair_potential.lj_potential import vectorised_lennard_jones_potential
+from local_optimisation.newton_raphson import newton_raphson_multi
+from calculus.difference.difference import first_central_multi, second_central_multi
+from local_optimisation.bfgs import bfgs
+
+x = np.array([[1.0132226417, 0.3329955686, 0.1812866397],
+              [0.7255989775, -0.7660449415, 0.2388625373],
+              [0.7293356067, -0.2309436666, -0.7649239428],
+              [0.3513618941, 0.8291166557, -0.5995702064],
+              [0.3453146118, -0.0366957540, 1.0245903005],
+              [0.1140240770, 0.9491685999, 0.5064104273],
+              [-1.0132240213, -0.3329960305, -0.1812867552],
+              [-0.1140234764, -0.9491689127, -0.5064103454],
+              [-0.3513615244, -0.8291170821, 0.5995701458],
+              [-0.3453152548, 0.0366956843, -1.0245902691],
+              [-0.7255983925, 0.7660457628, -0.2388624662],
+              [-0.7293359733, 0.2309438428, 0.7649237858],
+              [0.0000008339, 0.0000002733, 0.0000001488]])
+
+
+def first_diff(r):
+    return first_central_multi(lj_potential, r, 0.00001)
+
+
+def second_diff(r):
+    return second_central_multi(lj_potential, r, 0.00001)
+
+
+def lj_potential(x):
+    return fast_pair_potential(x, potential=vectorised_lennard_jones_potential, args=())
+
+
+
+
+
+if __name__ == '__main__':
+    rarray = bfgs(lj_potential, x, first_diff, 1e-5)
+    print(rarray)
+
+    def test_function(x):
+        y = x * x
+        return float(y.sum())
+
+    def first_diff_test(r):
+        return first_central_multi(test_function, r, 0.00001)
+
+
+    def second_diff_test(r):
+        return second_central_multi(test_function, r, 0.00001)
+
+    original_x = np.array([[0,1],[2,3]],dtype=float)
+    result=bfgs(test_function,original_x,first_diff_test,1e-7)
+    print(result)

--- a/local_optimisation/bfgs.py
+++ b/local_optimisation/bfgs.py
@@ -27,7 +27,7 @@ def bfgs_update_hessian(binv, y, s):
 
 
 def take_step(f, x0, df0, binv):
-    p = -binv @ df0
+    p = (-binv @ df0.reshape(-1)).reshape(x0.shape)
     alpha = line_search(f, x0, p, df0)
     return x0 + alpha * p
 
@@ -52,6 +52,6 @@ def bfgs(f, x0, df, xtol=1e-5, gtol=1e-5):
     b_inv = np.eye(x0.size)
 
     while any((norm((x1 := take_step(f, x0, df0, b_inv)) - x0) > xtol, norm(df1 := df(x1)) > gtol),):
-        b_inv = bfgs_update_hessian(b_inv, df1 - df0, x1 - x0)
+        b_inv = bfgs_update_hessian(b_inv, (df1 - df0).reshape(-1), (x1 - x0).reshape(-1))
         x0, df0 = x1, df1
     return x1

--- a/local_optimisation/line_search.py
+++ b/local_optimisation/line_search.py
@@ -20,7 +20,7 @@ def line_search(f, x, p, gx, c=0.5, t=0.5, max_alpha=1):
     :rtype: float
 
     """
-    m = p @ gx
+    m = p.reshape(-1) @ gx.reshape(-1)
     if m >= 0:
         raise ValueError(f"no function decrease guaranteed in search direction p (p @ gx = {p @ gx})")
 


### PR DESCRIPTION
The method provided previously do not support variables in shape of n*d ndarrays. To be specific, when it comes to lj_potential, the variables are in shape of 13*3 ndarrays, the rank of matrix do not match. The matrix B_{k+1} are in shape of 39*39 and line search method finding m = p@df are in shape of p_{39*1} @df_{13*3} ,causing a crash. 
This commit reshaped the ndarrays to support such kind of variables and a simple test is included in the Exer4_24.py . Since global optimisation seems to be a exercise for class , it only checked that the data provided in ./pair_potential/test/_lj13.txt is a local minimum,rather than trying to find the global minimum . And the code works well for test function f([[a,b],[c,d]]) = a^2+b^2+c^2+d^2, the minimum of which is at point [[0,0],[0,0]]